### PR TITLE
Fix usage of time.sleep

### DIFF
--- a/racbot.py
+++ b/racbot.py
@@ -19,7 +19,7 @@ PASSWORD = environ.get('RACBOT_PASSWORD')
 CLIENT_ID = environ.get('RACBOT_CLIENT_ID')
 CLIENT_SECRET = environ.get('RACBOT_CLIENT_SECRET')
 DEBUG = environ.get('RACBOT_DEBUG')
-SLEEP_TIMEOUT = environ.get('RACBOT_SLEEP_TIMEOUT', 300)
+SLEEP_TIMEOUT = int(environ.get('RACBOT_SLEEP_TIMEOUT', '300'))
 
 USER_AGENT = 'script:reddit anti-censorship bot:v0.1.0:created by /u/rpdorm'
 
@@ -82,6 +82,8 @@ def scan_new_threads():
                 f_thread_permalink.close()
             f_threads.write(submission.id + '\n')
     check_removed()
+
+    log('Pausing for {}s...'.format(SLEEP_TIMEOUT))
     time.sleep(SLEEP_TIMEOUT)
 
 def check_removed():


### PR DESCRIPTION
When I extracted the amount of seconds of the sleep timeout between runs
I accidentally forgot to convert the string returned by `environ.get` to
the number `time.sleep` needs. 💩

```
Traceback (most recent call last):
  File "./racbot.py", line 141, in <module>
    scan_new_threads()
  File "./racbot.py", line 85, in scan_new_threads
    time.sleep(SLEEP_TIMEOUT)
TypeError: a float is required
```